### PR TITLE
changed build speed and enabled caching

### DIFF
--- a/.devcontainer/Dockerfile_Caching
+++ b/.devcontainer/Dockerfile_Caching
@@ -1,0 +1,26 @@
+FROM ghcr.io/patpat98/bubble_blue:jazzy-desktop
+
+# Install ROS dependencies
+# This is done in a previous stage, but we include it again here in case anyone wants to
+# add new dependencies during development
+ENV USERNAME=ubuntu
+ENV USER_WORKSPACE=/home/$USERNAME/ws_blue
+WORKDIR $USER_WORKSPACE
+
+COPY --chown=$USER_UID:$USER_GID . src/blue
+RUN sudo apt-get -q update \
+    && sudo apt-get -q -y upgrade \
+    && rosdep update \
+    && rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} --skip-keys="gz-transport12 gz-sim7 gz-math7 gz-msgs9 gz-plugin2" \
+    && sudo apt-get autoremove -y \
+    && sudo apt-get clean -y \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Install debugging/linting Python packages
+RUN python3 -m pip install \
+    pre-commit \
+    mypy
+
+# Disable the setuputils installation warning
+# This prevents us from needing to pin the setuputils version (which doesn't always work)
+ENV PYTHONWARNINGS="ignore"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
 {
   "name": "Bubble Blue Dev Container",
-  "dockerFile": "Dockerfile",
+  "dockerFile": "Dockerfile_Caching",
   "context": "..",
-  "cacheFrom": [
-    "ghcr.io/patpat98/bubble_blue:jazzy-desktop"
-  ],
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/ubuntu/ws_blue/src/blue,type=bind",
   "workspaceFolder": "/home/ubuntu/ws_blue/src/blue",
   "remoteUser": "ubuntu",

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -127,7 +127,7 @@ RUN sudo apt-get -q update \
 
 # Actually build workspace
 RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
-    && colcon build --parallel-workers 2
+    && MAKEFLAGS="-j8 -l6.0" colcon build
 
 RUN echo "source ${USER_WORKSPACE}/install/setup.bash" >> /home/$USERNAME/.bashrc \
     && echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/$USERNAME/.bashrc \
@@ -215,7 +215,7 @@ RUN sudo apt-get -q update \
 # Modify the 'colcon build' line to be 'MAKEFLAGS="-j1 -l1" colcon build'
 # This will limit the amount of RAM that colcon is allowed to use
 RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
-    && MAKEFLAGS="-j1 -l1" colcon build
+    &&  MAKEFLAGS="-j8 -l6.0" colcon build
 
 # Setup the simulation environment variables
 RUN  <<EOT cat >> /home/$USERNAME/.bashrc


### PR DESCRIPTION
## Changes Made

Added more workers and higher threshold cpu use for building ros images. Made it such that the devcontainer caches from the image in the container registry. 

## Testing

Tested both functionalities. higher-performance building worked fine on my machine but we may need to bump it down for lower-performance machines
